### PR TITLE
Removing non-alphanumeric characters from tokens

### DIFF
--- a/src/OneSignalPushAdapter.js
+++ b/src/OneSignalPushAdapter.js
@@ -161,7 +161,7 @@ export class OneSignalPushAdapter {
     this.sendNext = function() {
       post['include_android_reg_ids'] = [];
       tokens.slice(offset,offset+chunk).forEach(function(i) {
-        post['include_android_reg_ids'].push(i['deviceToken'])
+        post['include_android_reg_ids'].push(i['deviceToken'].replace(/[^0-9a-z]/gi, ''))
       })
       offset+=chunk;
       this.sendToOneSignal(post, handleResponse);


### PR DESCRIPTION
`include_ios_tokens ` is a legacy key which should be replaced by `include_player_ids`.
As an alternative to embedding iOS SDK to get player_ids, docs specifies that in an ios_token `All non-alphanumeric characters must be removed`.
/!\ Please consider the warning: "Only works with Production tokens"

See: https://documentation.onesignal.com/v3.0/reference#section-send-to-specific-devices